### PR TITLE
Add on-device authentication

### DIFF
--- a/Assets/Scripts/LoginHandler.cs
+++ b/Assets/Scripts/LoginHandler.cs
@@ -9,10 +9,14 @@ public class LoginHandler : MonoBehaviour
     AndroidJavaObject jo;
 
     public void Login() {
-	jc = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
-	jo = jc.GetStatic<AndroidJavaObject>("currentActivity");
-	JNIStorage.apiClass.CallStatic("login", jo);
-    	hasAttemptedLogin = true;
+	if (FindObjectOfType<LoginText>().getMsaCode() != "") {
+	    Application.OpenURL("https://login.live.com/oauth20_remoteconnect.srf?otc=" + FindObjectOfType<LoginText>().getMsaCode());
+	} else {
+	    jc = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+	    jo = jc.GetStatic<AndroidJavaObject>("currentActivity");
+	    JNIStorage.apiClass.CallStatic("login", jo);
+    	    hasAttemptedLogin = true;
+	}
     }
 
     public void Update()

--- a/Assets/Scripts/LoginText.cs
+++ b/Assets/Scripts/LoginText.cs
@@ -1,15 +1,35 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using TMPro;
 using UnityEngine;
 public class LoginText : MonoBehaviour
 {
+    string code = "";
+
     void Update()
     {
         GetComponent<TextMeshProUGUI>().text = JNIStorage.apiClass.GetStatic<string>("msaMessage");
         if(GetComponent<TextMeshProUGUI>().text != "")
         {
-            GetComponent<TextMeshProUGUI>().text  = GetComponent<TextMeshProUGUI>().text + "Complete then you will be logged in.";
+	    string message = JNIStorage.apiClass.GetStatic<string>("msaMessage");
+
+            Match match = Regex.Match(message, "enter the code (\\w+)", RegexOptions.IgnoreCase);
+
+            if (match.Success)
+            {
+                code = match.Groups[1].Value;
+	 	        GetComponent<TextMeshProUGUI>().text  = GetComponent<TextMeshProUGUI>().text + "Complete to continue. To use on device authentication, please press 'Sign In' again.";
+            }
+            else 
+	        {
+		        code = "";
+		        GetComponent<TextMeshProUGUI>().text  = GetComponent<TextMeshProUGUI>().text + "Complete to continue.";
+            }
         }
+    }
+
+    public string getMsaCode(){
+    	return code;
     }
 }


### PR DESCRIPTION
It still runs with the remote code, but adds the functionality to enter the user infos in the Meta Quest Browser. Window is already called with the code filled in. CAD, I've sent you a video how it would work please take a look at it & the code